### PR TITLE
Sort files inside of parsed zips based on their name

### DIFF
--- a/src/components/Viewer/Viewer.jsx
+++ b/src/components/Viewer/Viewer.jsx
@@ -113,7 +113,7 @@ export default class Viewer extends React.Component {
       let imageFilenames = Object.keys(zip.files).filter(function (filename) {
         // Ignore non-image files
         return re.test(filename.toLowerCase());
-      });
+      }).sort((a, b) => a.localeCompare(b));
 
       let blobPromises = [];
       for (let filename of imageFilenames) {


### PR DESCRIPTION
I was having an issue where files would be displayed out-of-order even though they were named properly (1.jpg, 2.jpg, etc...) I think it has something to do with how MacOS orders files when they are added to a zip or something, as I encountered this only of zips I made myself on my machine. Anyways, I added some sorting.

This change enforces a relatively strict file naming standard (everything must be name xxxx01, xxxx02, and so on) but I think thats fine.

I use this application daily when reading manga for Japanese practice, so wanted to say thanks for developing this ✌️